### PR TITLE
📦 Implement Laravel 6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /composer.lock
 /yarn.lock
 /package-lock.json
+
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,19 @@ php:
 env:
   global:
     - COMPOSER_FLAGS=""
+    - COMPOSER_DISCARD_CHANGES=true
   matrix:
     - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.*
     - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.*
     - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.*
     - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=8.*
     - LARAVEL=6.* TESTBENCH=4.* PHPUNIT=8.*
+
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=8.*
+    - COMPOSER_FLAGS="--prefer-lowest" LARAVEL=6.* TESTBENCH=4.* PHPUNIT=8.*
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
+
+env:
+  global:
+    - COMPOSER_FLAGS=""
+  matrix:
+    - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.*
+    - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.*
+    - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.*
+    - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=8.*
+    - LARAVEL=6.* TESTBENCH=4.* PHPUNIT=8.*
 
 sudo: false
 
@@ -13,10 +21,12 @@ cache:
     - $HOME/.composer/cache
     - vendor
 
+before_install:
+  - travis_retry composer self-update
 
 install:
-  - travis_retry composer self-update
-  - travis_retry composer update --no-interaction --prefer-dist
+  - composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" "phpunit/phpunit:${PHPUNIT}" --prefer-source --no-interaction --no-suggest
+  - composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
   - php vendor/bin/phpcs --config-set ignore_warnings_on_exit 1

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8",
+    "phpunit/phpunit": "^8.0",
     "orchestra/testbench": "^4.0",
     "squizlabs/php_codesniffer": "^3.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
-    "orchestra/testbench": "~4.0",
+    "orchestra/testbench": "^4.0",
     "squizlabs/php_codesniffer": "^3.4"
   },
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
   "type": "package",
   "require": {
     "php": ">=7.0",
-    "illuminate/support": "^5.4",
-    "illuminate/database": "^5.4",
+    "illuminate/support": "^5.4 | ^6.0",
+    "illuminate/database": "^5.4 | ^6.0",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.7",
-    "orchestra/testbench": "~3.0",
+    "phpunit/phpunit": "^8",
+    "orchestra/testbench": "~4.0",
     "squizlabs/php_codesniffer": "^3.4"
   },
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Export and import your models to/from JSON",
   "type": "package",
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.2",
     "illuminate/support": "^5.4 | ^6.0",
     "illuminate/database": "^5.4 | ^6.0",
     "ext-json": "*"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>

--- a/src/Helpers/JsonImporter.php
+++ b/src/Helpers/JsonImporter.php
@@ -5,6 +5,7 @@ namespace MathieuTu\JsonSyncer\Helpers;
 use BadMethodCallException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use MathieuTu\JsonSyncer\Contracts\JsonImportable;
 use MathieuTu\JsonSyncer\Exceptions\JsonDecodingException;
@@ -58,7 +59,7 @@ class JsonImporter
 
     protected function importAttributes($attributes): JsonImportable
     {
-        $attributes = array_only($attributes, $this->importable->getJsonImportableAttributes());
+        $attributes = Arr::only($attributes, $this->importable->getJsonImportableAttributes());
 
         return $this->importable instanceof Model ?  $this->importable->create($attributes) : $this->importable;
     }

--- a/src/Traits/JsonExporter.php
+++ b/src/Traits/JsonExporter.php
@@ -3,6 +3,7 @@
 namespace MathieuTu\JsonSyncer\Traits;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use MathieuTu\JsonSyncer\Helpers\JsonExporter as ExporterHelper;
 use MathieuTu\JsonSyncer\Helpers\RelationsInModelFinder;
 
@@ -24,7 +25,7 @@ trait JsonExporter
     public function getJsonExportableAttributes(): array
     {
         return $this->jsonExportableAttributes ?? array_filter($this->getFillable(), function ($attribute) {
-            return !ends_with($attribute, '_id');
+            return ! Str::endsWith($attribute, '_id');
         });
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ use MathieuTu\JsonSyncer\Tests\Stubs\Foo;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Currently upgrading a project to Laravel 6 and saw this package needed a few tweaks. I think the only actual changes required in the src directory are removing the global helper functions, but to get it working with the L6 testbench version (4.x) it needs PHPUnit 8 and all the related changes there.